### PR TITLE
fix: add Docker login for Quay.io authentication

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,15 +128,21 @@ jobs:
             -Dquarkus.container-image.build=true \
             -Dquarkus.container-image.push=false
 
+      - name: Login to Quay.io
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
       - name: Build and Push Container
         if: github.event_name != 'pull_request'
         run: |
           mvn -B clean package -DskipTests \
             -Dquarkus.container-image.build=true \
             -Dquarkus.container-image.push=true \
-            -Dquarkus.container-image.tag=${{ steps.sha.outputs.short }} \
-            -Dquarkus.container-image.username=${{ secrets.QUAY_USERNAME }} \
-            -Dquarkus.container-image.password=${{ secrets.QUAY_PASSWORD }}
+            -Dquarkus.container-image.tag=${{ steps.sha.outputs.short }}
 
       - name: Summary
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,29 @@ jobs:
           path: target/*-runner
           retention-days: 30
 
-  build-native-macos:
+  build-native-macos-x64:
+    name: Native macOS (x64)
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '21'
+          distribution: 'graalvm'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache: 'maven'
+
+      - name: Build Native Binary
+        run: mvn -B clean package -Pnative -DskipTests
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: kantra-rules-gen-macos-x64
+          path: target/*-runner
+          retention-days: 30
+
+  build-native-macos-arm64:
     name: Native macOS (ARM64)
     runs-on: macos-latest
     steps:
@@ -77,7 +99,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: kantra-rules-gen-macos
+          name: kantra-rules-gen-macos-arm64
           path: target/*-runner
           retention-days: 30
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,29 +59,7 @@ jobs:
           path: target/*-runner
           retention-days: 30
 
-  build-native-macos-x64:
-    name: Native macOS (x64)
-    runs-on: macos-13
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: graalvm/setup-graalvm@v1
-        with:
-          java-version: '21'
-          distribution: 'graalvm'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          cache: 'maven'
-
-      - name: Build Native Binary
-        run: mvn -B clean package -Pnative -DskipTests
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: kantra-rules-gen-macos-x64
-          path: target/*-runner
-          retention-days: 30
-
-  build-native-macos-arm64:
+  build-native-macos:
     name: Native macOS (ARM64)
     runs-on: macos-latest
     steps:
@@ -99,7 +77,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: kantra-rules-gen-macos-arm64
+          name: kantra-rules-gen-macos
           path: target/*-runner
           retention-days: 30
 


### PR DESCRIPTION
## Changes

- Add `docker/login-action@v3` step to properly authenticate with Quay.io before pushing container images
- This fixes the `401 UNAUTHORIZED` error in the Container Image build job

## Problem
The Quarkus JIB extension wasn't authenticating properly with registry credentials passed via Maven properties, causing:
```
RegistryUnauthorizedException: Unauthorized for quay.io/sshaaf/kantra-rules-gen
```

## Solution
Use the official Docker login action to store credentials in Docker's credential store, which JIB can then use automatically.