### PR TITLE
add option for annotated in Elements. 

### DIFF
--- a/src/main/java/dev/shaaf/kantra/rules/gen/KantraTool.java
+++ b/src/main/java/dev/shaaf/kantra/rules/gen/KantraTool.java
@@ -57,7 +57,7 @@ public class KantraTool {
             @ToolArg(description = "The operation to perform (e.g., CREATE_JAVA_CLASS_RULE, CREATE_FILE_CONTENT_RULE, CREATE_XML_RULE, VALIDATE_RULE, GET_HELP)")
             KantraOperation operation,
             @ToolArg(description = "JSON object containing operation parameters. " +
-                    "For CREATE_JAVA_CLASS_RULE: {ruleID, javaPattern, location (IMPORT/CLASS/METHOD_CALL/etc), message, category (MANDATORY/OPTIONAL/POTENTIAL), effort (1-5)}. " +
+                    "For CREATE_JAVA_CLASS_RULE: {ruleID, javaPattern, location (IMPORT/CLASS/METHOD_CALL/etc), message, category (MANDATORY/OPTIONAL/POTENTIAL), effort (1-5)}. if location is ANNOTATION, you can also provide an annotated condition. " +
                     "For CREATE_FILE_CONTENT_RULE: {ruleID, filePattern, contentPattern, message, category, effort}. " +
                     "For CREATE_XML_RULE: {ruleID, xpath, message, category, effort}. " +
                     "For VALIDATE_RULE: {yamlContent}. " +


### PR DESCRIPTION
rule generation could not add Elements with annotated pattern
```
- ruleID: spring-framework-5.x-to-6.0-web-applications-00001
  category: potential
  effort: 1
  labels:
  - konveyor.io/source=spring5
  - konveyor.io/target=spring6+
  - konveyor.io/source=spring-boot2
  - konveyor.io/target=spring-boot3+
  when:
    java.referenced:
      pattern: org.springframework.web.bind.annotation.GetMapping
      location: ANNOTATION
      annotated:
        elements:
          - name: value
            value: '.*\/$'
  description: Trailing slash matching has changed in Spring 6.0
  message: |
    As of Spring Framework 6.0, the trailing slash matching configuration option has been deprecated and its default
    value set to false. This means that previously, the following controller would match both
    "GET /some/greeting" and "GET /some/greeting/":

    ```java
    @RestController
    public class MyController {
        @GetMapping("/some/greeting")
            public String greeting() {
            return "Hello";
        }
    }
    ```

    As of this Spring Framework change, "GET /some/greeting/" doesn't match anymore by default and will result in an
    HTTP 404 error. Developers should instead configure explicit redirects/rewrites through a proxy, a Servlet/web
    filter, or even declare the additional route explicitly on the controller handler
    (like @GetMapping("/some/greeting", "/some/greeting/") for more targeted cases.
    Until your application fully adapts to this change, you can change the default with the following
    global Spring MVC configuration:

    ```java
    @Configuration
    public class WebConfiguration implements WebMvcConfigurer {
        @Override
        public void configurePathMatch(PathMatchConfigurer configurer) {
            configurer.setUseTrailingSlashMatch(true);
        }
    }
    ```
  links:
  - title: 'Spring 6.0 migration guide'
    url: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.0-Release-Notes#web-applications
  - title: 'Specific Spring Framwork change'
    url: https://github.com/spring-projects/spring-framework/issues/28552
    ```